### PR TITLE
Fixed Current Match screen's one label constraint. Fixed a bug where …

### DIFF
--- a/USA Boccia Timer/ExternalDisplay/ExternalDisplayViewController.swift
+++ b/USA Boccia Timer/ExternalDisplay/ExternalDisplayViewController.swift
@@ -36,6 +36,7 @@ class ExternalDisplayViewController: UIViewController {
     var timerName = "Timeout"
     var redBallImages = UIStackView()
     var blueBallImages = UIStackView()
+    var firstTime = 1
     
     override func viewWillLayoutSubviews() {
         super.viewWillLayoutSubviews()
@@ -263,8 +264,9 @@ class ExternalDisplayViewController: UIViewController {
                     return
                 }
                 
-                // Save all the ends labels for later use (this will hopefully only happens once)
-                if (currEndsCount == 6) {
+                // Save all the ends labels for later use (this will only happen once)
+                if (currEndsCount == 6 && firstTime == 1) {
+                    firstTime = 0
                     for i in 0..<6 {
                         allEndsViews?.append(endsStack!.arrangedSubviews[i])
                     }
@@ -446,6 +448,15 @@ class ExternalDisplayViewController: UIViewController {
         currentEnd += 1
         currEndsCount += 1
         currTieBreaker += 1
+        
+        if currTieBreaker > 3 {
+            let initEnds = currentEnd - currTieBreaker
+            let i = initEnds + currTieBreaker-3-1
+            endsStack!.arrangedSubviews[i].isHidden = true
+            let label = endsStack!.arrangedSubviews[i+1] as! UILabel
+            label.text = "..." + label.text!
+            
+        }
     }
     
     @objc func setRedTimer(_ notification: Notification) {
@@ -538,11 +549,14 @@ class ExternalDisplayViewController: UIViewController {
                 
                 if resetString == "HardReset" {
                     // reset internal records of ends
+                    if currTieBreaker != 0 {
+                        currEndsCount = currentEnd - currTieBreaker
+                    }
                     currentEnd = 1
                     currTieBreaker = 0
                     
                     // reset to 4 total ends
-                    for i in (4..<endsStack!.arrangedSubviews.count).reversed() {
+                    for i in (currEndsCount..<endsStack!.arrangedSubviews.count).reversed() {
                         endsStack!.arrangedSubviews[i].removeFromSuperview()
                     }
                     

--- a/USA Boccia Timer/InputScoreViewController.swift
+++ b/USA Boccia Timer/InputScoreViewController.swift
@@ -161,10 +161,12 @@ class InputScoreViewController: UIViewController
 	 
 	 let item = currentEndItem
 	 delegate?.inputScoreViewController(self, didFinishAdding: item)
+         
+          // Update external display
+          NotificationCenter.default.post(name: Notification.Name("NextEnd"), object: nil, userInfo: ["message": ""])
       }
        
        // Update external display
-       NotificationCenter.default.post(name: Notification.Name("NextEnd"), object: nil, userInfo: ["message": ""])
        NotificationCenter.default.post(name: Notification.Name("ClearScoreboard"), object: nil, userInfo: ["message": ""])
    }
    

--- a/USA Boccia Timer/Main.storyboard
+++ b/USA Boccia Timer/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="22505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="qFZ-hN-Jgx">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="32700.99.1234" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="qFZ-hN-Jgx">
     <device id="ipad10_9rounded" orientation="portrait" layout="fullscreen" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22504"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22685"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
@@ -29,7 +29,7 @@
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Event Name:" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="kBt-VW-WYj">
-                                                    <rect key="frame" x="20" y="11" width="156" height="53"/>
+                                                    <rect key="frame" x="20" y="14" width="156" height="47"/>
                                                     <color key="tintColor" name="AccentColor"/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="156" id="8bQ-hJ-Tv8"/>
@@ -39,7 +39,7 @@
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" userInteractionEnabled="NO" tag="1" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="(Tap to set Name of Game Event)" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="5yw-s2-TBp">
-                                                    <rect key="frame" x="212" y="12.5" width="480" height="50"/>
+                                                    <rect key="frame" x="212" y="15.5" width="480" height="44"/>
                                                     <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="480" id="cd3-eP-kJY"/>
@@ -76,7 +76,7 @@
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Red Team" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="FJj-sd-fnQ">
-                                                    <rect key="frame" x="20" y="11" width="24" height="53"/>
+                                                    <rect key="frame" x="20" y="14" width="24" height="47"/>
                                                     <color key="tintColor" name="AccentColor"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="28"/>
                                                     <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
@@ -138,7 +138,7 @@
                                                     </constraints>
                                                 </imageView>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Blue Team" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="5mw-I4-ian">
-                                                    <rect key="frame" x="20" y="11" width="30" height="53"/>
+                                                    <rect key="frame" x="20" y="14" width="30" height="47"/>
                                                     <color key="tintColor" name="AccentColor"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="28"/>
                                                     <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
@@ -235,7 +235,7 @@
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <segmentedControl opaque="NO" tag="5" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="top" segmentControlStyle="plain" selectedSegmentIndex="0" translatesAutoresizingMaskIntoConstraints="NO" id="dV3-Tk-VsL">
-                                                    <rect key="frame" x="386" y="13" width="302" height="32"/>
+                                                    <rect key="frame" x="386" y="16" width="302" height="32"/>
                                                     <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="295.99999999995362" id="sfd-NT-dk9"/>
@@ -276,13 +276,13 @@
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Classification:" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="YpO-sX-LNR">
-                                                    <rect key="frame" x="20" y="12" width="169" height="33.5"/>
+                                                    <rect key="frame" x="20" y="15" width="169" height="33.5"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="28"/>
                                                     <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="TaM-VO-Jhz">
-                                                    <rect key="frame" x="425.5" y="3" width="244" height="49"/>
+                                                    <rect key="frame" x="425.5" y="6" width="244" height="43"/>
                                                     <state key="normal" title="Button"/>
                                                     <buttonConfiguration key="configuration" style="filled" title="Pick Classification">
                                                         <fontDescription key="titleFontDescription" type="system" pointSize="28"/>
@@ -419,7 +419,7 @@
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Times:" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="L3E-Q6-ute">
-                                                    <rect key="frame" x="20" y="11" width="80" height="33"/>
+                                                    <rect key="frame" x="20" y="14" width="80" height="27"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="28"/>
                                                     <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                     <nil key="highlightedColor"/>
@@ -547,16 +547,10 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="12" translatesAutoresizingMaskIntoConstraints="NO" id="PDs-YK-5Im">
-                                        <rect key="frame" x="43.5" y="96" width="215.5" height="36"/>
+                                        <rect key="frame" x="80.5" y="96" width="141" height="36"/>
                                         <subviews>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Current End:" textAlignment="center" lineBreakMode="tailTruncation" minimumScaleFactor="0.01" translatesAutoresizingMaskIntoConstraints="NO" id="qQs-wW-Fnn">
-                                                <rect key="frame" x="0.0" y="0.0" width="182.5" height="36"/>
-                                                <fontDescription key="fontDescription" type="system" weight="heavy" pointSize="200"/>
-                                                <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                                <nil key="highlightedColor"/>
-                                            </label>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="0" textAlignment="center" lineBreakMode="tailTruncation" minimumScaleFactor="0.01" translatesAutoresizingMaskIntoConstraints="NO" id="cfo-3y-I8o">
-                                                <rect key="frame" x="194.5" y="0.0" width="21" height="36"/>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="End 0" textAlignment="center" lineBreakMode="tailTruncation" minimumScaleFactor="0.01" translatesAutoresizingMaskIntoConstraints="NO" id="cfo-3y-I8o">
+                                                <rect key="frame" x="0.0" y="0.0" width="141" height="36"/>
                                                 <fontDescription key="fontDescription" type="system" weight="heavy" pointSize="200"/>
                                                 <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <nil key="highlightedColor"/>
@@ -1170,7 +1164,7 @@
                             <constraint firstItem="Eo5-0f-YG9" firstAttribute="width" secondItem="X6c-sg-7Fg" secondAttribute="width" multiplier="0.134233" id="9wM-Y1-fxJ"/>
                             <constraint firstItem="hYR-9t-e37" firstAttribute="width" secondItem="X6c-sg-7Fg" secondAttribute="width" multiplier="0.0568182" id="AJ0-Dw-dKT"/>
                             <constraint firstItem="ECR-ms-e0L" firstAttribute="width" secondItem="X6c-sg-7Fg" secondAttribute="width" multiplier="0.0568182" id="AVJ-oz-CE6"/>
-                            <constraint firstItem="cfo-3y-I8o" firstAttribute="width" secondItem="X6c-sg-7Fg" secondAttribute="width" multiplier="0.0298295" id="BiF-Ha-RhS"/>
+                            <constraint firstItem="cfo-3y-I8o" firstAttribute="width" secondItem="X6c-sg-7Fg" secondAttribute="width" multiplier="0.2" id="BiF-Ha-RhS"/>
                             <constraint firstItem="2Vl-Nn-fgs" firstAttribute="width" secondItem="X6c-sg-7Fg" secondAttribute="width" multiplier="0.429688" id="CLq-iU-vU6"/>
                             <constraint firstItem="ruS-LK-8Kx" firstAttribute="width" secondItem="X6c-sg-7Fg" secondAttribute="width" multiplier="0.0568182" id="CYh-de-pov"/>
                             <constraint firstItem="tUF-LP-Y0R" firstAttribute="width" secondItem="X6c-sg-7Fg" secondAttribute="width" multiplier="0.125" id="CiV-FL-apv"/>
@@ -1181,7 +1175,6 @@
                             <constraint firstItem="yvJ-R4-4Dx" firstAttribute="centerX" secondItem="X6c-sg-7Fg" secondAttribute="centerX" id="EPo-o6-7hg"/>
                             <constraint firstItem="Stg-xs-aQ2" firstAttribute="height" secondItem="X6c-sg-7Fg" secondAttribute="height" multiplier="0.033" id="ERr-m6-U5h"/>
                             <constraint firstItem="dsE-Ho-6jB" firstAttribute="width" secondItem="X6c-sg-7Fg" secondAttribute="width" multiplier="0.272727" id="Egf-Tp-Mp8"/>
-                            <constraint firstItem="PDs-YK-5Im" firstAttribute="width" secondItem="X6c-sg-7Fg" secondAttribute="width" multiplier="0.306108" id="EzZ-h2-ThD"/>
                             <constraint firstItem="chq-zX-5kP" firstAttribute="height" secondItem="X6c-sg-7Fg" secondAttribute="height" multiplier="0.0361627" id="I2B-wO-BX8"/>
                             <constraint firstItem="ZwB-b0-XeS" firstAttribute="height" secondItem="X6c-sg-7Fg" secondAttribute="height" multiplier="0.0100452" id="I30-9a-Lvv"/>
                             <constraint firstItem="c9o-oH-sMO" firstAttribute="height" secondItem="X6c-sg-7Fg" secondAttribute="height" multiplier="0.0100452" id="Ina-uZ-VLS"/>
@@ -1202,7 +1195,6 @@
                             <constraint firstItem="2Vl-Nn-fgs" firstAttribute="centerX" secondItem="X6c-sg-7Fg" secondAttribute="centerX" id="TF9-4A-Vhc"/>
                             <constraint firstItem="s9m-b7-G8z" firstAttribute="height" secondItem="X6c-sg-7Fg" secondAttribute="height" multiplier="0.0361627" id="UFA-5E-bPj"/>
                             <constraint firstItem="iC4-Ks-pyh" firstAttribute="width" secondItem="X6c-sg-7Fg" secondAttribute="width" multiplier="0.129261" id="Uob-JQ-f6K"/>
-                            <constraint firstItem="qQs-wW-Fnn" firstAttribute="width" secondItem="X6c-sg-7Fg" secondAttribute="width" multiplier="0.259233" id="Vhx-aV-ikh"/>
                             <constraint firstItem="Iia-9R-vuK" firstAttribute="width" secondItem="X6c-sg-7Fg" secondAttribute="width" multiplier="0.12571" id="WHs-Vh-FmG"/>
                             <constraint firstItem="U4n-v0-ybc" firstAttribute="width" secondItem="X6c-sg-7Fg" secondAttribute="width" multiplier="0.125" id="WUo-Pc-mhl"/>
                             <constraint firstItem="ncG-zv-WkT" firstAttribute="centerX" secondItem="X6c-sg-7Fg" secondAttribute="centerX" id="Wea-c8-jub"/>
@@ -1232,7 +1224,6 @@
                             <constraint firstItem="sD0-47-3WT" firstAttribute="height" secondItem="X6c-sg-7Fg" secondAttribute="height" multiplier="0.0401808" id="eED-WP-sFx"/>
                             <constraint firstItem="cfo-3y-I8o" firstAttribute="height" secondItem="X6c-sg-7Fg" secondAttribute="height" multiplier="0.0361627" id="fX0-37-LM9"/>
                             <constraint firstItem="naL-v4-eEb" firstAttribute="width" secondItem="X6c-sg-7Fg" secondAttribute="width" multiplier="0.0951705" id="ghP-jN-3zy"/>
-                            <constraint firstItem="qQs-wW-Fnn" firstAttribute="height" secondItem="X6c-sg-7Fg" secondAttribute="height" multiplier="0.0361627" id="gnn-QB-D8X"/>
                             <constraint firstItem="7eb-5h-NLW" firstAttribute="height" secondItem="X6c-sg-7Fg" secondAttribute="height" multiplier="0.025" id="gwg-O8-bWY"/>
                             <constraint firstItem="Stg-xs-aQ2" firstAttribute="width" secondItem="X6c-sg-7Fg" secondAttribute="width" multiplier="0.125" id="hRv-3r-V8Z"/>
                             <constraint firstItem="OY3-nh-4VM" firstAttribute="height" secondItem="X6c-sg-7Fg" secondAttribute="height" multiplier="0.0361627" id="hXk-Rg-gvJ"/>
@@ -1262,7 +1253,6 @@
                             <constraint firstItem="I3k-B3-A3V" firstAttribute="height" secondItem="X6c-sg-7Fg" secondAttribute="height" multiplier="0.0512305" id="tlg-QA-Nkf"/>
                             <constraint firstItem="ECR-ms-e0L" firstAttribute="height" secondItem="X6c-sg-7Fg" secondAttribute="height" multiplier="0.0401808" id="u8E-hJ-ubF"/>
                             <constraint firstItem="V0E-i7-gqi" firstAttribute="height" secondItem="X6c-sg-7Fg" secondAttribute="height" multiplier="0.0381718" id="ubC-vf-Ui5"/>
-                            <constraint firstItem="PDs-YK-5Im" firstAttribute="height" secondItem="X6c-sg-7Fg" secondAttribute="height" multiplier="0.0361627" id="v0h-4m-dEp"/>
                             <constraint firstItem="ncG-zv-WkT" firstAttribute="height" secondItem="X6c-sg-7Fg" secondAttribute="height" multiplier="0.3556" id="wHp-LY-FHX"/>
                             <constraint firstItem="giE-lC-ljg" firstAttribute="height" secondItem="X6c-sg-7Fg" secondAttribute="height" multiplier="0.0361627" id="wKn-9h-Tu7"/>
                             <constraint firstItem="sFP-c3-qGu" firstAttribute="width" secondItem="X6c-sg-7Fg" secondAttribute="width" multiplier="0.203125" id="wbR-k6-dYE"/>
@@ -2096,7 +2086,7 @@
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Boccia Timer" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wj7-hh-Ng4">
-                                                    <rect key="frame" x="107" y="13" width="530.5" height="107.5"/>
+                                                    <rect key="frame" x="107" y="10" width="530.5" height="107.5"/>
                                                     <fontDescription key="fontDescription" type="boldSystem" pointSize="90"/>
                                                     <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     <nil key="highlightedColor"/>
@@ -2122,7 +2112,7 @@
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="08Z-4i-g5W">
-                                                    <rect key="frame" x="202" y="28" width="300" height="160"/>
+                                                    <rect key="frame" x="202" y="31" width="300" height="154"/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="300" id="xbs-Ql-O8F"/>
                                                     </constraints>
@@ -2153,7 +2143,7 @@
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="pj5-Ts-pbZ">
-                                                    <rect key="frame" x="202" y="11" width="300" height="100"/>
+                                                    <rect key="frame" x="202" y="14" width="300" height="94"/>
                                                     <constraints>
                                                         <constraint firstAttribute="height" constant="100" id="Jbq-x1-JD9"/>
                                                         <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="300.00000000012733" id="a0k-6J-Ilf"/>
@@ -2195,25 +2185,25 @@
             <objects>
                 <tableViewController modalPresentationStyle="fullScreen" id="ggf-dq-FGb" customClass="HistoryTableViewController" customModule="USA_Boccia_Timer" customModuleProvider="target" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" keyboardDismissMode="interactive" dataMode="prototypes" style="plain" separatorStyle="default" allowsSelection="NO" rowHeight="415" estimatedRowHeight="-1" sectionHeaderHeight="-1" estimatedSectionHeaderHeight="-1" sectionFooterHeight="-1" estimatedSectionFooterHeight="-1" id="FgV-Kp-RwM">
-                        <rect key="frame" x="0.0" y="0.0" width="820" height="1180"/>
+                        <rect key="frame" x="0.0" y="0.0" width="704" height="995.5"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" red="0.0" green="0.098039215686274508" blue="0.39215686274509803" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <prototypes>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" reuseIdentifier="HistoryCell" rowHeight="415" id="dN6-MX-ZOj">
-                                <rect key="frame" x="0.0" y="50" width="820" height="415"/>
+                                <rect key="frame" x="0.0" y="50" width="704" height="415"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="dN6-MX-ZOj" id="bRh-kC-YEq">
-                                    <rect key="frame" x="0.0" y="0.0" width="820" height="415"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="704" height="415"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <label opaque="NO" userInteractionEnabled="NO" tag="2" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Game Name Label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="klY-TE-Ees">
-                                            <rect key="frame" x="233.5" y="59" width="353.5" height="54"/>
+                                            <rect key="frame" x="177.5" y="62" width="353.5" height="54"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="45"/>
                                             <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <label opaque="NO" userInteractionEnabled="NO" tag="3" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" verticalCompressionResistancePriority="751" text="Team Versus String" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="YSy-NN-aFP">
-                                            <rect key="frame" x="266.5" y="122" width="287" height="40"/>
+                                            <rect key="frame" x="210.5" y="125" width="287" height="40"/>
                                             <constraints>
                                                 <constraint firstAttribute="height" constant="40" id="QKO-e7-xXj"/>
                                             </constraints>
@@ -2222,13 +2212,13 @@
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <label opaque="NO" userInteractionEnabled="NO" tag="1" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" verticalCompressionResistancePriority="751" text="Date Game Played" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="VSP-xH-lBO">
-                                            <rect key="frame" x="311" y="13" width="198.5" height="30"/>
+                                            <rect key="frame" x="255" y="16" width="198.5" height="30"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="25"/>
                                             <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <stackView opaque="NO" contentMode="scaleToFill" spacing="240" translatesAutoresizingMaskIntoConstraints="NO" id="NtS-Rf-f8J">
-                                            <rect key="frame" x="189" y="178" width="442" height="66"/>
+                                            <rect key="frame" x="131" y="181" width="442" height="66"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" tag="4" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="R00" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="j3O-Sb-Ogi">
                                                     <rect key="frame" x="0.0" y="0.0" width="101" height="66"/>
@@ -3355,16 +3345,16 @@
             <color red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>
         <systemColor name="systemBlueColor">
-            <color red="0.0" green="0.47843137250000001" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <color red="0.0" green="0.47843137254901963" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
         <systemColor name="systemGray4Color">
-            <color red="0.81960784310000001" green="0.81960784310000001" blue="0.83921568629999999" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <color red="0.81960784313725488" green="0.81960784313725488" blue="0.83921568627450982" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
         <systemColor name="systemRedColor">
-            <color red="1" green="0.23137254900000001" blue="0.18823529410000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <color red="1" green="0.23137254901960785" blue="0.18823529411764706" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
         <systemColor name="tableCellBlueTextColor">
-            <color red="0.0" green="0.47843137250000001" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <color red="0.0" green="0.47843137254901963" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
     </resources>
 </document>

--- a/USA Boccia Timer/PenaltyThrowTimerViewController.swift
+++ b/USA Boccia Timer/PenaltyThrowTimerViewController.swift
@@ -50,6 +50,9 @@ class PenaltyThrowTimerViewController: UIViewController
    {
       //Invalidate Timer
       timer?.invalidate()
+       
+       // Update external display
+       NotificationCenter.default.post(name: Notification.Name("DismissTimer"), object: nil, userInfo: ["message": ""])
    }
    
    //MARK:  - Actions
@@ -82,9 +85,6 @@ class PenaltyThrowTimerViewController: UIViewController
       //Close the TimeOut Screen
       timer?.invalidate()
       navigationController?.popViewController(animated: true)
-       
-       // Update external display
-       NotificationCenter.default.post(name: Notification.Name("DismissTimer"), object: nil, userInfo: ["message": ""])
       
    }
    

--- a/USA Boccia Timer/TimeOutViewController.swift
+++ b/USA Boccia Timer/TimeOutViewController.swift
@@ -99,9 +99,7 @@ class TimeOutViewController: UIViewController
       //Close the TimeOut Screen
       timer?.invalidate()
       navigationController?.popViewController(animated: true)
-       
-       // Update external display
-       NotificationCenter.default.post(name: Notification.Name("DismissTimer"), object: nil, userInfo: ["message": ""])
+
    }
    
    

--- a/USA Boccia Timer/WarmUpTimerViewController.swift
+++ b/USA Boccia Timer/WarmUpTimerViewController.swift
@@ -43,6 +43,7 @@ class WarmUpTimerViewController: UIViewController
    
    override func viewWillDisappear(_ animated: Bool)
    {
+       // Update external display
       NotificationCenter.default.post(name: Notification.Name("DismissTimer"), object: nil, userInfo: ["message": ""])
       
       //Invalidate Timer


### PR DESCRIPTION
…finishing a medical/technical timer caused the external display to show the introduction screen. Fixed another bug where the app crashed due to the external display's NextEnd notification being called (in addition to NewTiebreakerEnd) when the next end is a tiebreaker.